### PR TITLE
feat: Enable iOS native compilation in Valdi Bazel integration

### DIFF
--- a/bzl/valdi/valdi_module.bzl
+++ b/bzl/valdi/valdi_module.bzl
@@ -1073,13 +1073,10 @@ def _setup_native_target(name, deps, additional_native_deps, compiled_module_tar
 
     valdi_module_native(
         name = ios_native_lib_name,
-        # TODO(simon): Make native compilation configurable on a per platform basis
-        # Disable on iOS for now to unblock.
-        srcs = [],
-        # srcs = source_set_select(
-        #     debug = [":ios.debug.c"],
-        #     release = [":ios.release.c"],
-        # ),
+        srcs = source_set_select(
+            debug = [":ios.debug.c"],
+            release = [":ios.release.c"],
+        ),
         deps = native_deps + additional_native_deps,
     )
 


### PR DESCRIPTION
This commit completes the Bazel Valdi integration by enabling native code compilation for iOS targets. Previously, the iOS native library was created with empty sources (srcs = []), preventing the Valdi-generated C code from being compiled into iOS native views.

Changes:
- Enabled iOS native source compilation in _setup_native_target function
- Removed TODO comment about disabling iOS compilation
- iOS now properly compiles both debug and release native C files
- Android native compilation was already enabled and remains unchanged

This allows Valdi modules to fully compile into native views for both iOS and Android platforms, completing the cross-platform native integration.