### PR TITLE
fix: Remove React Fragment syntax from PluginManagementScreen

### DIFF
--- a/modules/omnitak_mobile/src/valdi/omnitak/screens/PluginManagementScreen.tsx
+++ b/modules/omnitak_mobile/src/valdi/omnitak/screens/PluginManagementScreen.tsx
@@ -205,47 +205,51 @@ export class PluginManagementScreen extends Component<
 
       {/* Action buttons */}
       <view style={styles.pluginActions}>
-        {plugin.installed ? (
-          <>
-            {plugin.enabled ? (
-              <view
-                style={styles.actionButton}
-                onClick={() => this.handleDisable(plugin.id)}
-              >
-                <label
-                  value="Disable"
-                  font={systemFont(12, 'bold')}
-                  color="#FF9800"
-                />
-              </view>
-            ) : (
-              <view
-                style={styles.actionButton}
-                onClick={() => this.handleEnable(plugin.id)}
-              >
-                <label
-                  value="Enable"
-                  font={systemFont(12, 'bold')}
-                  color="#4CAF50"
-                />
-              </view>
-            )}
+        {plugin.installed && plugin.enabled && (
+          <view
+            style={styles.actionButton}
+            onClick={() => this.handleDisable(plugin.id)}
+          >
+            <label
+              value="Disable"
+              font={systemFont(12, 'bold')}
+              color="#FF9800"
+            />
+          </view>
+        )}
 
-            <view
-              style={styles.iconButton}
-              onClick={() => this.handleSettings(plugin.id)}
-            >
-              <label value="⚙️" font={systemFont(16)} />
-            </view>
+        {plugin.installed && !plugin.enabled && (
+          <view
+            style={styles.actionButton}
+            onClick={() => this.handleEnable(plugin.id)}
+          >
+            <label
+              value="Enable"
+              font={systemFont(12, 'bold')}
+              color="#4CAF50"
+            />
+          </view>
+        )}
 
-            <view
-              style={styles.iconButton}
-              onClick={() => this.handleUninstall(plugin.id)}
-            >
-              <label value="🗑️" font={systemFont(16)} />
-            </view>
-          </>
-        ) : (
+        {plugin.installed && (
+          <view
+            style={styles.iconButton}
+            onClick={() => this.handleSettings(plugin.id)}
+          >
+            <label value="⚙️" font={systemFont(16)} />
+          </view>
+        )}
+
+        {plugin.installed && (
+          <view
+            style={styles.iconButton}
+            onClick={() => this.handleUninstall(plugin.id)}
+          >
+            <label value="🗑️" font={systemFont(16)} />
+          </view>
+        )}
+
+        {!plugin.installed && (
           <view
             style={styles.actionButtonPrimary}
             onClick={() => this.handleInstall(plugin.id)}


### PR DESCRIPTION
The Valdi JSX transformer doesn't support React Fragment syntax (<>...</>), which was causing minification errors during the build process.

Replaced the ternary with fragments with individual conditional renders using the && operator, matching the pattern used in other working Valdi components (MapScreen, SettingsScreen).

This fix resolves the minification error that was blocking the iOS build.