### PR TITLE
fix: Correct Vercel deployment configuration for promotional site

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,6 @@
 {
-  "buildCommand": "cd website && npm install && npm run build",
+  "buildCommand": "cd website && npm run build",
   "outputDirectory": "website/.next",
   "installCommand": "cd website && npm install",
-  "framework": null,
-  "rewrites": [
-    {
-      "source": "/(.*)",
-      "destination": "/website/$1"
-    }
-  ]
+  "framework": "nextjs"
 }

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,7 +1,7 @@
 {
-  "buildCommand": "cd website && npm run build",
-  "outputDirectory": "website/out",
-  "installCommand": "cd website && npm install",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next",
+  "installCommand": "npm install",
   "framework": "nextjs",
   "regions": ["iad1"],
   "github": {


### PR DESCRIPTION
The site was returning 403 due to misconfigured vercel.json files:
- Removed incorrect rewrites in root vercel.json that were breaking routing
- Set framework to "nextjs" (was null)
- Fixed output directory in website/vercel.json from "out" to ".next"
- Aligned build commands with actual Next.js build process

This should resolve the deployment issues at omni-tak-mobile.vercel.app