### PR TITLE
Update promotional site to indicate version 1.3.8 is now available on…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to OmniTAK Mobile will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.8] - 2025-01-22
+
+### Release
+- **App Store Release**: Version 1.3.8 is now available on the iOS App Store
+- Production-ready build with all previous fixes and features
+
 ## [1.3.7] - 2025-01-21
 
 ### Fixed
@@ -113,6 +119,7 @@ This project uses [Semantic Versioning](https://semver.org/):
 - **Minor (0.X.0)**: New features, backward compatible
 - **Patch (0.0.X)**: Bug fixes
 
+[1.3.8]: https://github.com/engindearing-projects/omniTAK-mobile/compare/v1.3.7...v1.3.8
 [1.3.7]: https://github.com/engindearing-projects/omniTAK-mobile/compare/v1.3.0...v1.3.7
 [1.3.0]: https://github.com/engindearing-projects/omniTAK-mobile/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/engindearing-projects/omniTAK-mobile/compare/v1.1.0...v1.2.0

--- a/website/README.md
+++ b/website/README.md
@@ -4,12 +4,12 @@ A cutting-edge promotional website for OmniTAK Mobile, built with Next.js 14 and
 
 ## Features
 
-- ✨ **Futuristic Design**: Glassmorphism, animated particles, and gradient effects
-- 🎨 **Advanced Animations**: Framer Motion for smooth, professional animations
-- 📱 **Fully Responsive**: Optimized for all devices
-- 🔄 **Live Changelog**: Automatically syncs with CHANGELOG.md from the main repo
-- 🎯 **Performance Optimized**: Static export for blazing-fast load times
-- 🌐 **SEO Ready**: Proper meta tags and semantic HTML
+- **Futuristic Design**: Glassmorphism, animated particles, and gradient effects
+- **Advanced Animations**: Framer Motion for smooth, professional animations
+- **Fully Responsive**: Optimized for all devices
+- **Live Changelog**: Automatically syncs with CHANGELOG.md from the main repo
+- **Performance Optimized**: Static export for blazing-fast load times
+- **SEO Ready**: Proper meta tags and semantic HTML
 
 ## Tech Stack
 

--- a/website/app/api/changelog/route.ts
+++ b/website/app/api/changelog/route.ts
@@ -48,9 +48,9 @@ export async function GET() {
     return NextResponse.json(
       [
         {
-          version: '1.0.0',
-          date: '2024-01-15',
-          changes: ['Initial release with ATAK compatibility', 'iOS support', 'Team communication features'],
+          version: '1.3.8',
+          date: '2025-01-22',
+          changes: ['App Store Release: Version 1.3.8 is now available on the iOS App Store', 'Production-ready build with all previous fixes and features'],
         },
       ]
     );


### PR DESCRIPTION
… App Store

- Added version 1.3.8 entry to CHANGELOG.md with App Store release announcement
- Updated fallback version in changelog API route from 1.0.0 to 1.3.8
- Removed emoji icons from website README for cleaner documentation