### PR TITLE
Update promotional site for 2025 and add Engindearing website link

### DIFF
--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -4,7 +4,7 @@ export default function Footer() {
   return (
     <footer className="relative py-16 px-4 border-t border-white/10">
       <div className="max-w-7xl mx-auto">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-12 mb-12">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-12 mb-12">
           <div>
             <h3 className="text-2xl font-bold text-gradient mb-4">OmniTAK</h3>
             <p className="text-gray-400 text-sm">
@@ -41,11 +41,21 @@ export default function Footer() {
               <li><a href="https://github.com/engindearing-projects/omniTAK-mobile/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" className="text-omni-grey-light hover:text-omni-teal transition-colors">MIT License</a></li>
             </ul>
           </div>
+
+          <div>
+            <h4 className="font-bold mb-4 text-omni-olive">Company</h4>
+            <ul className="space-y-2 text-sm">
+              <li><a href="https://www.engindearing.soy" target="_blank" rel="noopener noreferrer" className="text-omni-grey-light hover:text-omni-teal transition-colors">Engindearing</a></li>
+            </ul>
+          </div>
         </div>
 
         <div className="border-t border-white/10 pt-8 text-center text-sm text-gray-400">
-          <p>© 2024 OmniTAK Mobile. Open source and MIT licensed.</p>
+          <p>© 2025 OmniTAK Mobile. Open source and MIT licensed.</p>
           <p className="mt-2">Built for tactical professionals and first responders worldwide.</p>
+          <p className="mt-2">
+            A project by <a href="https://www.engindearing.soy" target="_blank" rel="noopener noreferrer" className="text-omni-teal hover:text-omni-olive transition-colors font-medium">Engindearing</a>
+          </p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
- Update copyright year from 2024 to 2025
- Add new "Company" section in footer with link to www.engindearing.soy
- Add Engindearing attribution in footer text
- Adjust footer grid layout to accommodate new column