### PR TITLE
Fix crash after marker deletion

### DIFF
--- a/apps/omnitak/OmniTAKMobile/Features/Drawing/Services/PointDropperService.swift
+++ b/apps/omnitak/OmniTAKMobile/Features/Drawing/Services/PointDropperService.swift
@@ -131,6 +131,12 @@ class PointDropperService: ObservableObject {
 
     /// Delete a marker
     func deleteMarker(_ marker: PointMarker) {
+        // Clear selected marker if it's the one being deleted
+        if selectedMarker?.id == marker.id {
+            selectedMarker = nil
+            dropperState = .idle
+        }
+
         markers.removeAll { $0.id == marker.id }
         recentMarkers.removeAll { $0.id == marker.id }
         saveMarkers()
@@ -150,6 +156,10 @@ class PointDropperService: ObservableObject {
 
     /// Delete all markers
     func deleteAllMarkers() {
+        // Clear selected marker
+        selectedMarker = nil
+        dropperState = .idle
+
         markers.removeAll()
         recentMarkers.removeAll()
         saveMarkers()
@@ -160,6 +170,12 @@ class PointDropperService: ObservableObject {
 
     /// Delete markers by affiliation
     func deleteMarkers(affiliation: MarkerAffiliation) {
+        // Clear selected marker if it matches the affiliation being deleted
+        if let selected = selectedMarker, selected.affiliation == affiliation {
+            selectedMarker = nil
+            dropperState = .idle
+        }
+
         let count = markers.filter { $0.affiliation == affiliation }.count
         markers.removeAll { $0.affiliation == affiliation }
         recentMarkers.removeAll { $0.affiliation == affiliation }

--- a/apps/omnitak/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuMapCoordinator.swift
+++ b/apps/omnitak/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuMapCoordinator.swift
@@ -153,7 +153,13 @@ class RadialMenuMapCoordinator: ObservableObject {
         // Trigger haptic feedback
         RadialMenuHaptic.itemSelect.trigger()
 
-        // Dismiss menu first
+        // For delete actions, clear context immediately to prevent stale references
+        let isDeleteAction = action.identifier == "delete"
+        if isDeleteAction {
+            currentContext = nil
+        }
+
+        // Dismiss menu
         dismissMenu()
 
         // Execute the action


### PR DESCRIPTION
- Clear selectedMarker and reset dropperState when deleting markers in PointDropperService to prevent stale references
- Clear radial menu context immediately for delete actions to prevent accessing deleted marker data during the 250ms animation delay
- Apply fix to all deletion methods: deleteMarker, deleteAllMarkers, and deleteMarkers(affiliation:)

Fixes crash reported on iOS 26.1 / iPhone 16 Pro Max after deleting a marker via radial menu.