### PR TITLE
Update color scheme to match neon green logo branding

### DIFF
--- a/apps/omnitak_android/app_assets/android/values/colors.xml
+++ b/apps/omnitak_android/app_assets/android/values/colors.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- OmniTAK Brand Colors -->
-    <color name="omnitak_primary">#1B5E20</color>          <!-- Dark Green - Military -->
-    <color name="omnitak_primary_dark">#0D3818</color>     <!-- Darker Green -->
-    <color name="omnitak_accent">#4CAF50</color>           <!-- Bright Green Accent -->
+    <!-- OmniTAK Brand Colors - Neon Green Theme -->
+    <color name="omnitak_primary">#16A34A</color>          <!-- Deep Green - Primary -->
+    <color name="omnitak_primary_dark">#0A1628</color>     <!-- Dark Navy Background -->
+    <color name="omnitak_accent">#4ADE80</color>           <!-- Neon Green Accent (matches logo) -->
 
     <!-- Background Colors -->
-    <color name="splash_bg">#0D3818</color>                <!-- Launch screen background -->
-    <color name="background_primary">#121212</color>       <!-- Dark background -->
-    <color name="background_secondary">#1E1E1E</color>     <!-- Lighter dark background -->
+    <color name="splash_bg">#0A1628</color>                <!-- Launch screen - dark navy -->
+    <color name="background_primary">#0A1628</color>       <!-- Dark navy background -->
+    <color name="background_secondary">#162033</color>     <!-- Lighter navy background -->
 
     <!-- Map Colors -->
     <color name="map_overlay">#80000000</color>            <!-- Semi-transparent black -->
@@ -22,7 +22,7 @@
     <color name="text_secondary">#B0B0B0</color>
 
     <!-- Status Colors -->
-    <color name="status_connected">#4CAF50</color>
+    <color name="status_connected">#4ADE80</color>
     <color name="status_connecting">#FFC107</color>
     <color name="status_disconnected">#F44336</color>
 </resources>

--- a/modules/omnitak_mobile/src/valdi/omnitak/components/AddServerDialog.tsx
+++ b/modules/omnitak_mobile/src/valdi/omnitak/components/AddServerDialog.tsx
@@ -245,7 +245,7 @@ export class AddServerDialog extends Component<
             <label
               value="Use username/password to enroll"
               font={systemFont(11)}
-              color="#4CAF50"
+              color="#4ADE80"
               marginTop={2}
             />
           </view>
@@ -280,7 +280,7 @@ export class AddServerDialog extends Component<
             <label
               value="From file or PKCS#12 bundle"
               font={systemFont(11)}
-              color="#4CAF50"
+              color="#4ADE80"
               marginTop={2}
             />
           </view>
@@ -301,11 +301,11 @@ export class AddServerDialog extends Component<
         {/* Selected certificate display */}
         {selectedCertId && (
           <view style={styles.selectedCertBox}>
-            <label value="✓" font={systemBoldFont(16)} color="#4CAF50" marginRight={8} />
+            <label value="✓" font={systemBoldFont(16)} color="#4ADE80" marginRight={8} />
             <label
               value={`Certificate configured: ${selectedCertId}`}
               font={systemFont(12)}
-              color="#4CAF50"
+              color="#4ADE80"
             />
           </view>
         )}
@@ -500,7 +500,7 @@ const styles = {
     padding: 12,
     borderRadius: 4,
     borderWidth: 1,
-    borderColor: '#4CAF50',
+    borderColor: '#4ADE80',
     marginTop: 8,
   }),
 

--- a/modules/omnitak_mobile/src/valdi/omnitak/components/CertificateEnrollmentDialog.tsx
+++ b/modules/omnitak_mobile/src/valdi/omnitak/components/CertificateEnrollmentDialog.tsx
@@ -86,7 +86,7 @@ export class CertificateEnrollmentDialog extends Component<
             <label
               value={serverUrl}
               font={systemFont(14)}
-              color="#4CAF50"
+              color="#4ADE80"
             />
           </view>
 
@@ -163,11 +163,11 @@ export class CertificateEnrollmentDialog extends Component<
           {/* Success message */}
           {success && (
             <view style={styles.successBox}>
-              <label value="✓" font={systemBoldFont(18)} color="#4CAF50" marginRight={8} />
+              <label value="✓" font={systemBoldFont(18)} color="#4ADE80" marginRight={8} />
               <label
                 value="Certificate enrolled successfully!"
                 font={systemFont(12)}
-                color="#4CAF50"
+                color="#4ADE80"
               />
             </view>
           )}
@@ -296,7 +296,7 @@ const styles = {
     padding: 12,
     borderRadius: 4,
     borderWidth: 1,
-    borderColor: '#4CAF50',
+    borderColor: '#4ADE80',
     marginBottom: 8,
   }),
 
@@ -361,7 +361,7 @@ const styles = {
     padding: 12,
     borderRadius: 4,
     borderLeftWidth: 3,
-    borderLeftColor: '#4CAF50',
+    borderLeftColor: '#4ADE80',
     marginTop: 16,
   }),
 

--- a/modules/omnitak_mobile/src/valdi/omnitak/components/CertificateImportDialog.tsx
+++ b/modules/omnitak_mobile/src/valdi/omnitak/components/CertificateImportDialog.tsx
@@ -162,11 +162,11 @@ export class CertificateImportDialog extends Component<
           {/* Success message */}
           {success && (
             <view style={styles.successBox}>
-              <label value="✓" font={systemBoldFont(18)} color="#4CAF50" marginRight={8} />
+              <label value="✓" font={systemBoldFont(18)} color="#4ADE80" marginRight={8} />
               <label
                 value="Certificate imported successfully!"
                 font={systemFont(12)}
-                color="#4CAF50"
+                color="#4ADE80"
               />
             </view>
           )}
@@ -309,7 +309,7 @@ export class CertificateImportDialog extends Component<
             <label
               value={file.filename || 'Selected file'}
               font={systemFont(14)}
-              color="#4CAF50"
+              color="#4ADE80"
             />
             <label
               value="Tap to change"
@@ -319,7 +319,7 @@ export class CertificateImportDialog extends Component<
             />
           </view>
           <view style={styles.checkMark}>
-            <label value="✓" font={systemBoldFont(16)} color="#4CAF50" />
+            <label value="✓" font={systemBoldFont(16)} color="#4ADE80" />
           </view>
         </view>
       ) : (
@@ -466,7 +466,7 @@ const styles = {
     padding: 12,
     borderRadius: 4,
     borderWidth: 1,
-    borderColor: '#4CAF50',
+    borderColor: '#4ADE80',
   }),
 
   fileInfo: new Style<View>({
@@ -510,7 +510,7 @@ const styles = {
     padding: 12,
     borderRadius: 4,
     borderLeftWidth: 3,
-    borderLeftColor: '#4CAF50',
+    borderLeftColor: '#4ADE80',
     marginTop: 16,
   }),
 

--- a/modules/omnitak_mobile/src/valdi/omnitak/screens/CertificateManagementScreen.tsx
+++ b/modules/omnitak_mobile/src/valdi/omnitak/screens/CertificateManagementScreen.tsx
@@ -182,7 +182,7 @@ export class CertificateManagementScreen extends Component<
             <label
               value={`Used by: ${cert.associatedServers.join(', ')}`}
               font={systemFont(11)}
-              color="#4CAF50"
+              color="#4ADE80"
               marginTop={4}
             />
           </view>
@@ -293,7 +293,7 @@ export class CertificateManagementScreen extends Component<
   private getStatusColor(status: string): string {
     switch (status) {
       case 'valid':
-        return '#4CAF50';
+        return '#4ADE80';
       case 'expiring_soon':
         return '#FFA500';
       case 'expired':
@@ -396,7 +396,7 @@ const styles = {
     padding: 12,
     borderRadius: 4,
     borderLeftWidth: 3,
-    borderLeftColor: '#4CAF50',
+    borderLeftColor: '#4ADE80',
     marginBottom: 16,
   }),
 

--- a/modules/omnitak_mobile/src/valdi/omnitak/screens/EnhancedMapScreen.tsx
+++ b/modules/omnitak_mobile/src/valdi/omnitak/screens/EnhancedMapScreen.tsx
@@ -147,7 +147,7 @@ export class EnhancedMapScreen extends Component<
             <label
               value={isConnected ? 'CONN' : 'DISC'}
               font={systemBoldFont(9)}
-              color={isConnected ? '#4CAF50' : '#FF5252'}
+              color={isConnected ? '#4ADE80' : '#FF5252'}
               marginLeft={6}
             />
           </view>
@@ -656,7 +656,7 @@ const styles = {
     width: 8,
     height: 8,
     borderRadius: 4,
-    backgroundColor: '#4CAF50',
+    backgroundColor: '#4ADE80',
     // Pulsing animation effect
   }),
 

--- a/modules/omnitak_mobile/src/valdi/omnitak/screens/FederatedServerScreen.tsx
+++ b/modules/omnitak_mobile/src/valdi/omnitak/screens/FederatedServerScreen.tsx
@@ -137,7 +137,7 @@ export class FederatedServerScreen extends Component<
           <label
             value="Connect All"
             font={systemBoldFont(12)}
-            color="#4CAF50"
+            color="#4ADE80"
             marginLeft={6}
           />
         </view>
@@ -221,7 +221,7 @@ export class FederatedServerScreen extends Component<
           <label
             value={server.status === 'connected' ? 'Disconnect' : 'Connect'}
             font={systemBoldFont(12)}
-            color={server.status === 'connected' ? '#FF5252' : '#4CAF50'}
+            color={server.status === 'connected' ? '#FF5252' : '#4ADE80'}
           />
         </view>
       </view>
@@ -268,7 +268,7 @@ export class FederatedServerScreen extends Component<
                 <label
                   value={server.policy.blueTeamOnly ? '✓' : '○'}
                   font={systemBoldFont(12)}
-                  color={server.policy.blueTeamOnly ? '#4CAF50' : '#666666'}
+                  color={server.policy.blueTeamOnly ? '#4ADE80' : '#666666'}
                 />
               </view>
               <label
@@ -294,7 +294,7 @@ export class FederatedServerScreen extends Component<
                 <label
                   value={server.policy.autoShare ? '✓' : '○'}
                   font={systemBoldFont(12)}
-                  color={server.policy.autoShare ? '#4CAF50' : '#666666'}
+                  color={server.policy.autoShare ? '#4ADE80' : '#666666'}
                 />
               </view>
               <label
@@ -581,7 +581,7 @@ const styles = {
     width: 12,
     height: 12,
     borderRadius: 6,
-    backgroundColor: '#4CAF50',
+    backgroundColor: '#4ADE80',
   }),
 
   ledConnecting: new Style<View>({
@@ -654,7 +654,7 @@ const styles = {
     borderRadius: 12,
     backgroundColor: 'rgba(76, 175, 80, 0.2)',
     borderWidth: 2,
-    borderColor: '#4CAF50',
+    borderColor: '#4ADE80',
     alignItems: 'center',
     justifyContent: 'center',
   }),

--- a/modules/omnitak_mobile/src/valdi/omnitak/screens/PluginManagementScreen.tsx
+++ b/modules/omnitak_mobile/src/valdi/omnitak/screens/PluginManagementScreen.tsx
@@ -165,7 +165,7 @@ export class PluginManagementScreen extends Component<
               <label
                 value="ACTIVE"
                 font={systemBoldFont(10)}
-                color="#4CAF50"
+                color="#4ADE80"
               />
             </view>
           )}
@@ -234,7 +234,7 @@ export class PluginManagementScreen extends Component<
                 <label
                   value="Enable"
                   font={systemBoldFont(12)}
-                  color="#4CAF50"
+                  color="#4ADE80"
                 />
               </view>
             )}
@@ -411,7 +411,7 @@ const styles = {
     backgroundColor: 'rgba(76, 175, 80, 0.2)',
     borderRadius: 4,
     borderWidth: 1,
-    borderColor: '#4CAF50',
+    borderColor: '#4ADE80',
   }),
 
   pluginMeta: new Style<View>({

--- a/modules/omnitak_mobile/src/valdi/omnitak/screens/ServerManagementScreen.tsx
+++ b/modules/omnitak_mobile/src/valdi/omnitak/screens/ServerManagementScreen.tsx
@@ -192,7 +192,7 @@ export class ServerManagementScreen extends Component<
             <label
               value="Connect"
               font={systemBoldFont(12)}
-              color="#4CAF50"
+              color="#4ADE80"
             />
           </view>
         )}
@@ -314,7 +314,7 @@ export class ServerManagementScreen extends Component<
   private getStatusColor(status: string): string {
     switch (status) {
       case 'connected':
-        return '#4CAF50';
+        return '#4ADE80';
       case 'connecting':
         return '#FFA500';
       case 'error':

--- a/modules/omnitak_mobile/src/valdi/omnitak/screens/SettingsScreen.tsx
+++ b/modules/omnitak_mobile/src/valdi/omnitak/screens/SettingsScreen.tsx
@@ -228,7 +228,7 @@ const styles = {
     width: 50,
     height: 30,
     borderRadius: 15,
-    backgroundColor: '#4CAF50',
+    backgroundColor: '#4ADE80',
     padding: 2,
     justifyContent: 'center',
     alignItems: 'flex-end',

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -6,8 +6,9 @@
   --foreground-rgb: 248, 250, 252;
   --background-start-rgb: 10, 22, 40;
   --background-end-rgb: 15, 23, 42;
-  --accent-rgb: 59, 130, 246;
-  --teal-rgb: 20, 184, 166;
+  --accent-rgb: 74, 222, 128;
+  --green-rgb: 74, 222, 128;
+  --green-dark-rgb: 34, 197, 94;
 }
 
 * {
@@ -41,8 +42,8 @@ body {
 }
 
 .card-hover:hover {
-  border-color: rgba(59, 130, 246, 0.5);
-  box-shadow: 0 0 30px rgba(59, 130, 246, 0.1);
+  border-color: rgba(74, 222, 128, 0.5);
+  box-shadow: 0 0 30px rgba(74, 222, 128, 0.1);
 }
 
 /* Glass effect - refined */
@@ -60,20 +61,20 @@ body {
   border: 1px solid rgba(30, 41, 59, 0.5);
 }
 
-/* Glow effects - professional */
+/* Glow effects - neon green */
 .glow-accent {
-  box-shadow: 0 0 20px rgba(59, 130, 246, 0.3),
-              0 0 40px rgba(59, 130, 246, 0.15);
+  box-shadow: 0 0 20px rgba(74, 222, 128, 0.3),
+              0 0 40px rgba(74, 222, 128, 0.15);
 }
 
-.glow-teal {
-  box-shadow: 0 0 20px rgba(20, 184, 166, 0.3),
-              0 0 40px rgba(20, 184, 166, 0.15);
+.glow-green {
+  box-shadow: 0 0 20px rgba(74, 222, 128, 0.4),
+              0 0 40px rgba(74, 222, 128, 0.2);
 }
 
-/* Text gradient - professional */
+/* Text gradient - neon green */
 .text-gradient {
-  background: linear-gradient(135deg, #3B82F6 0%, #14B8A6 100%);
+  background: linear-gradient(135deg, #4ADE80 0%, #22C55E 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -89,31 +90,31 @@ body {
 /* Subtle grid background */
 .grid-bg {
   background-image:
-    linear-gradient(rgba(59, 130, 246, 0.03) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(59, 130, 246, 0.03) 1px, transparent 1px);
+    linear-gradient(rgba(74, 222, 128, 0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(74, 222, 128, 0.03) 1px, transparent 1px);
   background-size: 60px 60px;
 }
 
 /* Section divider */
 .section-divider {
   height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(59, 130, 246, 0.3), transparent);
+  background: linear-gradient(90deg, transparent, rgba(74, 222, 128, 0.3), transparent);
 }
 
 /* Button styles */
 .btn-primary {
-  background: linear-gradient(135deg, #3B82F6 0%, #2563EB 100%);
-  color: white;
+  background: linear-gradient(135deg, #4ADE80 0%, #22C55E 100%);
+  color: #0A1628;
   font-weight: 600;
   padding: 0.875rem 2rem;
   border-radius: 8px;
   transition: all 0.3s ease;
-  border: 1px solid rgba(59, 130, 246, 0.3);
+  border: 1px solid rgba(74, 222, 128, 0.3);
 }
 
 .btn-primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 10px 30px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 10px 30px rgba(74, 222, 128, 0.3);
 }
 
 .btn-secondary {
@@ -127,9 +128,9 @@ body {
 }
 
 .btn-secondary:hover {
-  border-color: #3B82F6;
-  color: #3B82F6;
-  background: rgba(59, 130, 246, 0.1);
+  border-color: #4ADE80;
+  color: #4ADE80;
+  background: rgba(74, 222, 128, 0.1);
 }
 
 /* Scrollbar styling - professional */
@@ -142,17 +143,17 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: linear-gradient(135deg, #3B82F6 0%, #14B8A6 100%);
+  background: linear-gradient(135deg, #4ADE80 0%, #22C55E 100%);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #60A5FA;
+  background: #86EFAC;
 }
 
 /* Selection color */
 ::selection {
-  background-color: rgba(59, 130, 246, 0.3);
+  background-color: rgba(74, 222, 128, 0.3);
   color: #F8FAFC;
 }
 
@@ -163,8 +164,8 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15) 0%, rgba(20, 184, 166, 0.15) 100%);
-  border: 1px solid rgba(59, 130, 246, 0.2);
+  background: linear-gradient(135deg, rgba(74, 222, 128, 0.15) 0%, rgba(34, 197, 94, 0.15) 100%);
+  border: 1px solid rgba(74, 222, 128, 0.2);
   border-radius: 12px;
 }
 
@@ -178,7 +179,7 @@ body {
 }
 
 .capability-card:hover {
-  border-color: rgba(59, 130, 246, 0.5);
+  border-color: rgba(74, 222, 128, 0.5);
   transform: translateY(-4px);
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
 }
@@ -203,7 +204,7 @@ body {
   inset: 0;
   border-radius: inherit;
   padding: 1px;
-  background: linear-gradient(135deg, #3B82F6, #14B8A6, #3B82F6);
+  background: linear-gradient(135deg, #4ADE80, #22C55E, #4ADE80);
   background-size: 300% 300%;
   animation: gradient-x 8s ease infinite;
   -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
@@ -224,8 +225,8 @@ body {
 /* Hero background pattern */
 .hero-pattern {
   background-image:
-    radial-gradient(circle at 20% 50%, rgba(59, 130, 246, 0.08) 0%, transparent 50%),
-    radial-gradient(circle at 80% 50%, rgba(20, 184, 166, 0.08) 0%, transparent 50%);
+    radial-gradient(circle at 20% 50%, rgba(74, 222, 128, 0.08) 0%, transparent 50%),
+    radial-gradient(circle at 80% 50%, rgba(34, 197, 94, 0.08) 0%, transparent 50%);
 }
 
 /* Tag/Badge styling */
@@ -238,7 +239,7 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.05em;
   border-radius: 9999px;
-  background: rgba(59, 130, 246, 0.15);
-  color: #60A5FA;
-  border: 1px solid rgba(59, 130, 246, 0.3);
+  background: rgba(74, 222, 128, 0.15);
+  color: #86EFAC;
+  border: 1px solid rgba(74, 222, 128, 0.3);
 }

--- a/website/tailwind.config.ts
+++ b/website/tailwind.config.ts
@@ -10,24 +10,25 @@ const config: Config = {
     extend: {
       colors: {
         omni: {
-          // Professional defense tech color palette
+          // Neon Green Theme - matches logo
           navy: "#0A1628",           // Deep navy primary
           'navy-light': "#162033",   // Lighter navy
           slate: "#1E293B",          // Slate background
           'slate-light': "#334155",  // Lighter slate
           steel: "#475569",          // Steel grey
-          accent: "#3B82F6",         // Professional blue accent
-          'accent-light': "#60A5FA", // Lighter accent
-          teal: "#14B8A6",           // Teal for highlights
-          'teal-dark': "#0D9488",    // Darker teal
-          olive: "#84CC16",          // Tactical green
-          'olive-muted': "#65A30D",  // Muted olive
+          accent: "#4ADE80",         // Neon green accent (matches logo)
+          'accent-light': "#86EFAC", // Lighter green
+          'accent-dark': "#22C55E",  // Darker green
+          green: "#4ADE80",          // Primary neon green
+          'green-light': "#86EFAC",  // Light green
+          'green-dark': "#16A34A",   // Deep green
+          'green-glow': "#4ADE80",   // Glow effect green
           white: "#F8FAFC",          // Clean white
           grey: "#94A3B8",           // Neutral grey
           'grey-light': "#CBD5E1",   // Light grey
           'grey-dark': "#64748B",    // Dark grey
           border: "#1E293B",         // Border color
-          glow: "#3B82F6",           // Glow color
+          glow: "#4ADE80",           // Glow color (green)
         },
       },
       fontFamily: {


### PR DESCRIPTION
Changed the app-wide color scheme from blue (#3B82F6) and old green (#4CAF50) to a neon green theme (#4ADE80) matching the logo aesthetic.

- Android: Updated primary/accent colors and backgrounds to dark navy
- Website: Replaced blue accents with neon green throughout Tailwind config and global CSS (buttons, glows, gradients, borders)
- Mobile components: Updated all status indicators and UI elements to use the new neon green (#4ADE80)